### PR TITLE
Remove claim of Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        # TODO check Python 3.2 support of dependencies
-        #'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Topic :: Utilities',
         ],
     )


### PR DESCRIPTION
$ `flake8 . --count --builtins=ml_ops --select=E9,F63,F7,F82 --show-source --statistics`
```
./Hasher/hashes/common/orchestra.py:93:14: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
            print helpers.color("\n\n[*] Error: You must provide an action to perform", warning=True)
             ^
./Hasher/hashes/common/helpers.py:29:6: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
    print "#" * 80
     ^
./Hasher/hashes/ops/bcrypt.py:22:22: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
                    print helpers.color("Error: BCrypt requres a salt of 22 alphanumeric characters", warning=True)
                     ^
./Hasher/hashes/ops/postgres_md5.py:17:14: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
            print "You must provide a username for postgres_md5 hashes!"
             ^
./Hasher/hashes/ops/msdcc2.py:16:14: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
            print "You must provide a username for msdcc2 hashes!"
             ^
./Hasher/hashes/ops/msdcc.py:17:14: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
            print "You must provide a username for msdcc hashes!"
             ^
./Hasher/hashes/ops/oracle10.py:16:14: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
            print "You must provide a username for oracle10 hashes!"
             ^
./Hasher/hashes/ops/sha256_crypt.py:22:22: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
                    print helpers.color("Sha256_crypt and sha512_crypt require at least 1000 rounds.", warning=True)
                     ^
./Hasher/hashes/ops/sha512_crypt.py:22:22: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
                    print helpers.color("sha512_crypt and sha512_crypt require at least 1000 rounds.", warning=True)
                     ^
./Hasher/hashes/ops/cisco_pix.py:16:14: E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
            print "You must provide a username for cisco_pix hashes!"
             ^
10    E999 SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
```